### PR TITLE
Fix: utility failure, if first file is not .log*

### DIFF
--- a/src/Utility.php
+++ b/src/Utility.php
@@ -34,7 +34,7 @@ class Utility extends \craft\base\Utility
 		$logFiles = array_values(array_filter(
 			scandir($logsDir),
 			function ($var) {
-				return $var[0] != '.';
+				return $var[0] != '.' && strpos($var, '.log');
 			}
 		));
 


### PR DESCRIPTION
Utility will filter only valid files for the $logFiles list