### PR TITLE
Craft 5 Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1 - 2024-03-19
+### Fixed
+- Escape unsafe HTML, this allows XML and HTML tags to display as text instead of render
+
 ## 3.0.6 - 2022-05-10
 ### Fixed
 - Escape unsafe HTML, this allows XML and HTML tags to display as text instead of render

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0 - 2022-07-11
+### Changed
+- Craft 4 release
+
 ## 3.0.5 - 2021-11-23
 ### Added
 - Add truncate / delete buttons

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,10 @@
 {
   "name": "ether/logs",
   "description": "Access logs from the CP",
-  "version": "3.0.5",
   "type": "craft-plugin",
   "minimum-stability": "dev",
   "require": {
-    "craftcms/cms": "^3.0.0-RC1"
+    "craftcms/cms": "^4.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "ether/logs",
   "description": "Access logs from the CP",
-  "version": "3.0.6",
+  "version": "4.0.1",
   "type": "craft-plugin",
   "minimum-stability": "dev",
   "require": {

--- a/src/Logs.php
+++ b/src/Logs.php
@@ -27,7 +27,7 @@ class Logs extends Plugin
 
 		Event::on(
 			Utilities::class,
-			Utilities::EVENT_REGISTER_UTILITY_TYPES,
+			Utilities::EVENT_REGISTER_UTILITIES,
 			function (RegisterComponentTypesEvent $event) {
 				$event->types[] = Utility::class;
 			}

--- a/src/Service.php
+++ b/src/Service.php
@@ -11,15 +11,19 @@ class Service extends Component
 	public function truncate ($log)
 	{
 		$logsDir = Craft::getAlias('@storage/logs');
-		file_put_contents($logsDir . DIRECTORY_SEPARATOR . $log, '');
-		Craft::$app->getSession()->setNotice($log . ' truncated.');
+		$success = file_put_contents($logsDir . DIRECTORY_SEPARATOR . $log, '');
+
+		if ($success !== false) Craft::$app->getSession()->setNotice($log . ' truncated.');
+		else Craft::$app->getSession()->setError('Failed to truncate ' . $log . ', check file permissions');
 	}
 
 	public function delete ($log)
 	{
 		$logsDir = Craft::getAlias('@storage/logs');
-		unlink($logsDir . DIRECTORY_SEPARATOR . $log);
-		Craft::$app->getSession()->setNotice($log . ' deleted.');
+		$success = unlink($logsDir . DIRECTORY_SEPARATOR . $log);
+
+		if ($success !== false) Craft::$app->getSession()->setNotice($log . ' deleted.');
+		else Craft::$app->getSession()->setError('Failed to delete ' . $log . ', check file permissions');
 	}
 
 }

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -21,7 +21,7 @@ class Utility extends \craft\base\Utility
 		return 'logs';
 	}
 
-	public static function iconPath ()
+	public static function iconPath (): null|string
 	{
 		return Craft::getAlias('@ether/logs/utility_icon.svg');
 	}


### PR DESCRIPTION
Switches to new [`EVENT_REGISTER_UTILITIES`](https://craftcms.com/docs/5.x/extend/updating-plugins.html#utilities) event in `src/Logs.php` for Craft 5 compatibility. 

See issue #16 